### PR TITLE
fix: resolve #2 — Add an open-source license to the project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 St John Brown
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -146,3 +146,7 @@ src/
     └── ci-fixer.ts        Fixes failing CI on PRs
 ```
 
+## License
+
+[MIT](LICENSE)
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/main.ts",


### PR DESCRIPTION
## Summary

Adds an MIT license to the project, resolving a request from a member of the public. The MIT license was chosen as the most permissive widely-used option, allowing anyone to freely use, modify, and distribute the code with minimal restrictions.

## Changes

- Added `LICENSE` file with the full MIT license text (Copyright 2025 St John Brown)
- Added a "License" section to `README.md` linking to the license file
- Added `"license": "MIT"` field to `package.json`

Closes #2