### PR TITLE
docs: update documentation for claws-snapshot

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -53,7 +53,8 @@ src/
     ├── issue-auditor.ts        Daily audit ensuring no issues fall between the cracks
     ├── whatsapp-handler.ts     Interprets WhatsApp messages via Claude, creates GitHub issues
     ├── runner-monitor.ts       Monitors self-hosted GH Actions runners via SSH
-    └── ubuntu-latest-scanner.ts  Scans workflows for non-self-hosted runners, creates alert issues
+    ├── ubuntu-latest-scanner.ts  Scans workflows for non-self-hosted runners, creates alert issues
+    └── email-monitor.ts        Polls Gmail for veg box emails, generates recipe suggestions via Claude
 
 deploy/
 ├── claws.service           systemd service unit
@@ -68,7 +69,7 @@ deploy/
 
 **`main.ts`** — Wires everything together. Initializes the SQLite database,
 recovers orphaned tasks from a previous crash (cleans up dangling worktrees,
-marks tasks failed), prunes old logs, registers all 15 jobs with the scheduler
+marks tasks failed), prunes old logs, registers all 16 jobs with the scheduler
 (interval jobs staggered by 2 seconds to prevent thundering herd), starts the
 HTTP server, sets up live config reloading (interval and schedule changes
 propagated to the scheduler without restart), initializes the WhatsApp gateway
@@ -229,7 +230,7 @@ file context.
 
 ## Jobs
 
-Fifteen scheduled jobs run on timers or schedules, plus one event-driven handler.
+Sixteen scheduled jobs run on timers or schedules, plus one event-driven handler.
 See [Jobs](jobs.md) for detailed behavior of each.
 
 | Job | Trigger | Interval | Summary |
@@ -250,6 +251,7 @@ See [Jobs](jobs.md) for detailed behavior of each.
 | `whatsapp-handler` | WhatsApp message | Event-driven | Interprets messages via Claude, creates GitHub issues |
 | `runner-monitor` | Self-hosted GH Actions runners | 10 min | SSHes to runners, checks service health, restarts dead services, cleans disk |
 | `ubuntu-latest-scanner` | Daily at 6 AM | Scheduled | Scans workflow files for non-self-hosted runners, creates alert issues |
+| `email-monitor` | Unseen veg box emails | 5 min | Polls Gmail, extracts vegetables via Claude, generates recipes, sends reply email |
 
 ## Key Patterns
 
@@ -519,6 +521,12 @@ defaults.
 | `pausedJobs` | — | `[]` (job names to pause on startup) |
 | `skippedItems` | — | `[]` (array of `{repo, number}` excluded from processing) |
 | `prioritizedItems` | — | `[]` (array of `{repo, number}` processed first) |
+| `emailEnabled` | `CLAWS_EMAIL_ENABLED` | `false` |
+| `emailUser` | `CLAWS_EMAIL_USER` | *(empty)* |
+| `emailAppPassword` | `CLAWS_EMAIL_APP_PASSWORD` | *(empty)* |
+| `emailRecipient` | `CLAWS_EMAIL_RECIPIENT` | *(empty)* |
+| `emailVegBoxSender` | — | *(empty)* |
+| `intervals.emailMonitorMs` | — | `300000` (5 min) |
 
 Config changes made via the web UI (`POST /config`) take effect immediately
 at runtime — no restart required. The config module uses ESM live bindings
@@ -526,8 +534,8 @@ at runtime — no restart required. The config module uses ESM live bindings
 Interval and schedule changes are propagated to the scheduler via
 `onConfigChange()` listeners that call `updateInterval()` /
 `updateScheduledHour()`. The only exceptions are `port` (requires socket
-re-bind) and `whatsappEnabled` (requires QR pairing), which are shown as
-read-only in the UI.
+re-bind), `whatsappEnabled` (requires QR pairing), and `emailEnabled`
+(requires restart), which are shown as read-only in the UI.
 
 Env vars always take priority over `config.json`. Fields set via env var
 are shown as disabled in the config UI with a note indicating the override.

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -1,6 +1,6 @@
 # Jobs
 
-Most jobs follow the same lifecycle:
+Sixteen jobs follow the same lifecycle (plus one event-driven handler):
 
 1. List target issues/PRs via `gh` CLI
 2. For each item: record task in DB, create a git worktree, run Claude via the
@@ -10,7 +10,8 @@ Most jobs follow the same lifecycle:
 
 Exceptions: `auto-merger`, `repo-standards`, `runner-monitor`, and
 `ubuntu-latest-scanner` do not invoke Claude or create worktrees.
-`whatsapp-handler` is event-driven (not scheduled).
+`email-monitor` invokes Claude but does not create worktrees or interact
+with GitHub. `whatsapp-handler` is event-driven (not scheduled).
 
 ## issue-refiner
 
@@ -608,3 +609,34 @@ repo.
 
 Does not create worktrees, PRs, or invoke Claude — purely a filesystem scan
 with issue creation via the `gh` CLI.
+
+## email-monitor
+
+**Source**: `src/jobs/email-monitor.ts`
+**Trigger**: Unseen emails from the configured veg box sender
+**Interval**: 5 minutes (configurable via `intervals.emailMonitorMs`)
+**Requires**: `emailEnabled: true`, `emailUser`, and `emailAppPassword` configured
+
+A personal automation unrelated to GitHub. Polls a Gmail inbox via IMAP for
+unseen emails from a specific sender (the weekly veg box delivery
+notification). When a matching email is found:
+
+1. Extracts the plain text body from the email (handles multipart MIME and
+   quoted-printable encoding)
+2. Sends the email body to Claude to extract the vegetable list from the
+   "Regular Veg Size" section
+3. Sends the extracted list to Claude to generate 3–5 family-friendly recipe
+   ideas
+4. Sends the vegetable list and recipes as a reply email via SMTP
+5. Marks the original email as read to prevent reprocessing
+
+Two Claude invocations per email (extraction + recipe generation), both
+routed through the bounded Claude queue.
+
+**Email configuration**:
+- IMAP: `imap.gmail.com:993` (TLS)
+- SMTP: `smtp.gmail.com:465` (TLS)
+- Authentication via Gmail app password (`emailAppPassword`)
+
+Does not create worktrees, PRs, or interact with GitHub. Exposes
+`getEmailStatus()` for the dashboard status endpoint.


### PR DESCRIPTION
## Summary

Documentation updated to reflect the addition of the new `email-monitor` job — a personal automation that polls Gmail for weekly veg box delivery emails, extracts the vegetable list via Claude, generates recipe suggestions, and sends a reply email. All affected sections of OVERVIEW.md and jobs.md have been updated to account for the new job.

## Changes

- Added `email-monitor` to the source tree listing and jobs summary table in OVERVIEW.md
- Updated job count from 15 to 16 throughout OVERVIEW.md
- Documented email-related configuration fields (`emailEnabled`, `emailUser`, `emailAppPassword`, `emailRecipient`, `emailVegBoxSender`, `intervals.emailMonitorMs`)
- Noted `emailEnabled` as a read-only config field requiring restart
- Added full `email-monitor` job reference section in jobs.md covering trigger, interval, IMAP/SMTP details, and the two-step Claude invocation workflow
- Updated jobs.md introduction to note that `email-monitor` invokes Claude but does not create worktrees or interact with GitHub