### PR TITLE
fix: resolve #5 — Alert: workflow concurrency misconfiguration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - "**/*.md"
       - LICENSE
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
       - "**/*.md"
       - LICENSE
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary

Adds per-branch concurrency groups to the CI and Release GitHub Actions workflows. Without these, GitHub Actions uses a global mutex per workflow, causing jobs across different branches to queue up and cancel each other with "higher priority waiting request" errors. This fix scopes concurrency to each branch/PR, so pushes only cancel outdated runs on the same branch.

## Changes

- Added `concurrency: { group: ci-${{ github.ref }}, cancel-in-progress: true }` to `ci.yml`
- Added `concurrency: { group: release-${{ github.ref }}, cancel-in-progress: true }` to `release.yml`

Closes #5