### PR TITLE
docs: update documentation for claws-snapshot

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -552,7 +552,7 @@ The WhatsApp gateway requires a one-time QR-code pairing step. See
 - **Language**: TypeScript (strict mode, ES2022 target, Node16 modules, ESM)
 - **Database**: SQLite via better-sqlite3 (WAL mode)
 - **Testing**: Vitest — co-located test files, heavy mocking of external boundaries
-- **CI**: GitHub Actions on self-hosted runner — build + test on every push
+- **CI**: GitHub Actions on self-hosted runner — build + test on every push. Both CI and Release workflows use per-branch concurrency groups (`ci-${{ github.ref }}` / `release-${{ github.ref }}`) with `cancel-in-progress: true`, so newer pushes to the same branch cancel older runs while different branches run independently. Doc-only changes (`docs/**`, `**/*.md`, `LICENSE`) skip CI via `paths-ignore`.
 - **History cleanup**: Workflow-dispatch action for branch cleanup and `git-filter-repo` to audit/scrub git secrets
 - **Releases**: Date-based version tags (`v<YYYY-MM-DD>.<N>`), tarball attached to GitHub Release
 - **Auto-updates**: systemd timer checks for new releases every 60s, downloads + swaps + health checks with automatic rollback


### PR DESCRIPTION
## Summary

Updates the project overview documentation to reflect the CI and Release workflow improvements introduced in #6. The documentation now describes the per-branch concurrency groups, cancel-in-progress behavior, and paths-ignore filtering for doc-only changes.

## Changes

- **Updated CI description** in the Tech Stack section of `OVERVIEW.md` to document per-branch concurrency groups (`ci-${{ github.ref }}` / `release-${{ github.ref }}`) with `cancel-in-progress: true`
- **Added paths-ignore documentation** noting that doc-only changes (`docs/**`, `**/*.md`, `LICENSE`) skip CI runs