### PR TITLE
docs: update documentation for claws-snapshot

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -135,7 +135,9 @@ from PRs with in-progress checks).
 (`enqueue`) that runs up to `MAX_CLAUDE_WORKERS` (default 2) Claude processes in
 parallel; (2) git worktree helpers — `ensureClone`, `createWorktree`,
 `createWorktreeFromBranch`, `removeWorktree`, `attemptMerge`, `pushBranch`,
-`generatePRDescription`, etc. `ensureClone` (exported) clones a repo on first
+`generatePRDescription`, `generateDocsPRDescription` (lighter-weight variant
+for doc-only PRs), `regeneratePRDescription` (re-generates after review
+cycles), etc. `ensureClone` (exported) clones a repo on first
 use and on subsequent calls runs `git fetch --all --prune` followed by
 `git checkout origin/<defaultBranch> --force` to refresh the main clone's
 working directory — this ensures any code reading directly from the main clone
@@ -191,13 +193,12 @@ endpoints and config views require authentication via
 Token comparison uses `crypto.timingSafeEqual`.
 
 **`plan-parser.ts`** — Parses structured implementation plan comments into
-discrete phases for multi-PR workflows. Looks for `### PR N:` or `### Phase N:`
-headers to split a plan into phases. Also provides `findPlanComment()` to locate the
-most recent plan comment in an issue's comment history, `getPlanUpdatePhase()`
-to read the `<!-- plan-updated-after-phase:N -->` marker from plan text,
-and `makePlanUpdateFooter()` to generate the visible + machine-readable
-footer appended after plan updates. Used by issue-worker to implement
-multi-phase plans sequentially and update the plan between phases.
+discrete phases for multi-PR workflows. `parsePlan()` looks for `### PR N:`
+or `### Phase N:` headers to split a plan into phases (falls back to a
+single phase if no structure is found). `findPlanComment()` locates the most
+recent `## Implementation Plan` comment in an issue's comment history. Used
+by issue-worker to implement multi-phase plans sequentially and by
+doc-maintainer to extract plans from recently-closed issues.
 
 **`log.ts`** — Timestamped console logging with four levels: `debug`, `info`,
 `warn`, `error`. Errors also trigger Slack notifications. All log calls capture
@@ -324,7 +325,8 @@ cancellations.
 ### Crash Recovery
 
 At startup, any tasks still marked `running` in the database (from a previous
-crash) have their worktrees cleaned up and are marked `failed`.
+crash) have their worktrees cleaned up, stale git worktree metadata is pruned
+(`git worktree prune`), and the tasks are marked `failed`.
 
 ### Transient Retry & Rate Limit Circuit Breaker
 
@@ -394,7 +396,7 @@ Two jobs monitor CI infrastructure health:
   processes older than 6 hours only if the runner service is down), and
   monitors disk usage (cleans temp files when above 90%). Actions taken are
   reported via Slack. Runner hosts are configured with baked-in defaults
-  (two Hetzner servers, overridable via `runners` in `config.json`).
+  (one default host, overridable via `runners` in `config.json`).
 - **ubuntu-latest-scanner**: Daily scan of `.github/workflows/*.yml` files in
   all cloned repos. Detects `runs-on:` values that are not `self-hosted` and
   creates a deduped alert issue in the offending repo. Skips commented-out
@@ -509,7 +511,7 @@ defaults.
 | `schedules.ideaSuggesterHour` | — | `4` (4 AM local time) |
 | `schedules.issueAuditorHour` | — | `5` (5 AM local time) |
 | `schedules.ubuntuLatestScannerHour` | — | `6` (6 AM local time) |
-| `runners` | — | Two default self-hosted runner hosts (see config) |
+| `runners` | — | One default self-hosted runner host (see config) |
 | `logRetentionDays` | — | `14` |
 | `logRetentionPerJob` | — | `20` |
 | `whatsappEnabled` | `WHATSAPP_ENABLED` | `false` |

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -82,6 +82,8 @@ visual context.
 **Trigger**: Issues labelled `Refined`
 **Interval**: 5 minutes
 
+- Guards against duplicate work: if an open PR already exists for this issue,
+  removes `Refined` and skips (prevents creating a second PR)
 - Removes the `Ready` label (work starting)
 - Creates a worktree on branch `claws/issue-<N>-<hex4>`
 - Provides the issue title, body, and all comments as context
@@ -92,6 +94,7 @@ visual context.
   fails), creates a PR titled `fix: resolve #N — <title>` that closes
   the issue
 - Adds the `In Review` label to the issue (signals a PR is open for review)
+- Propagates the `Priority` label from the issue to the new PR (if present)
 - Removes the `Refined` label
 
 ### Multi-PR issues
@@ -104,11 +107,10 @@ creates one PR per phase:
 - The final PR uses `Closes #N` to auto-close the issue on merge
 - PR titles include `(N/total)` suffixes
 
-Before implementing each subsequent phase, the worker updates the plan comment
-to reflect completed work: completed phases get `[COMPLETED]` prepended to
-their titles, and remaining phases are revised to account for what has already
-been merged. A `<!-- plan-updated-after-phase:N -->` marker prevents redundant
-updates.
+Before implementing each subsequent phase, the worker posts a progress
+comment summarizing completed PRs and the next phase number. A
+`<!-- phase-progress:N -->` marker in the comment prevents duplicate posts.
+The original plan comment is preserved unmodified.
 
 Between phases, the worker scans open issues for ones with merged `claws/`
 PRs but more phases remaining. When a PR has been merged and more phases
@@ -302,7 +304,8 @@ For each canonical (non-duplicate) issue:
 - The `.plans/` directory is cleaned up after Claude runs and is never
   committed
 - Instructs Claude to create/update `docs/OVERVIEW.md` and supporting docs
-- If commits were produced: pushes and creates a PR titled
+- If commits were produced: generates a lightweight PR description
+  (`generateDocsPRDescription`), pushes and creates a PR titled
   `docs: update documentation for <repo>` (auto-merged by the auto-merger
   job once checks pass, with a safety guard ensuring only doc files are
   changed)
@@ -551,7 +554,7 @@ See [WhatsApp Setup](whatsapp-setup.md) for configuration and pairing.
 
 Monitors self-hosted GitHub Actions runner hosts via SSH. Unlike most jobs,
 this does not operate on GitHub repos — it directly manages infrastructure.
-Runner hosts are configured with baked-in defaults (two Hetzner servers),
+Runner hosts are configured with a baked-in default (one host),
 overridable via the `runners` array in `config.json`.
 
 For each configured runner (sequential, with per-host error reporting):


### PR DESCRIPTION
## Summary

Updates project documentation to reflect recent code changes across several areas: new PR description helpers, revised plan-parser behavior, crash recovery improvements, and infrastructure configuration changes. These docs align with the current implementation after recent feature work and simplifications.

## Changes

- **`OVERVIEW.md`**: Documented `generateDocsPRDescription` and `regeneratePRDescription` helpers in the worker infrastructure section
- **`OVERVIEW.md`**: Rewrote `plan-parser.ts` description to match simplified API — `parsePlan()` now falls back to a single phase, removed references to deleted `getPlanUpdatePhase`/`makePlanUpdateFooter` helpers
- **`OVERVIEW.md`**: Added `git worktree prune` step to crash recovery documentation
- **`OVERVIEW.md`**: Updated runner host defaults from two Hetzner servers to one default host (reflects current config)
- **`jobs.md`**: Added duplicate-work guard to issue-worker (skips if an open PR already exists)
- **`jobs.md`**: Documented `Priority` label propagation from issues to PRs
- **`jobs.md`**: Revised multi-PR phase progress tracking — replaced plan-comment mutation with progress comments using `<!-- phase-progress:N -->` markers
- **`jobs.md`**: Documented lightweight `generateDocsPRDescription` usage in doc-maintainer job
- **`jobs.md`**: Updated runner-monitor description to match one-host default